### PR TITLE
修复 Sass 废弃警告

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.1.1",
-        "sass": "^1.69.5",
+        "sass": "^1.83.0",
         "typescript": "^5.2.2",
         "vite": "^5.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.1.1",
-    "sass": "^1.69.5",
+    "sass": "^1.83.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import * as sass from 'sass';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -14,6 +15,14 @@ export default defineConfig({
     modules: {
       localsConvention: 'camelCase',
       generateScopedName: '[name]__[local]__[hash:base64:5]',
+    },
+    preprocessorOptions: {
+      scss: {
+        implementation: sass,
+        sassOptions: {
+          outputStyle: 'compressed',
+        },
+      },
     },
   },
 }); 


### PR DESCRIPTION
## 问题描述\n- Sass 的 legacy JS API 废弃警告\n\n## 解决方案\n- 更新 Sass 配置\n- 在 vite.config.ts 中添加正确的 Sass 配置\n- 使用新的 Sass API