### PR TITLE
修复 Sass @import 废弃警告

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,5 @@
-@import './variables.scss';
-@import './reset.scss';
+@use './variables' as *;
+@use './reset';
 
 /* Global styles */
 .container {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,5 @@
-@use './variables' as *;
-@use './reset';
+@forward './variables';
+@forward './reset';
 
 /* Global styles */
 .container {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import * as sass from 'sass';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -18,10 +17,8 @@ export default defineConfig({
     },
     preprocessorOptions: {
       scss: {
-        implementation: sass,
-        sassOptions: {
-          outputStyle: 'compressed',
-        },
+        charset: false,
+        additionalData: '@use "@/styles/variables" as *;',
       },
     },
   },


### PR DESCRIPTION
## 问题描述\n- Sass @import 规则已废弃\n\n## 解决方案\n- 使用 @forward 替代 @import\n- 更新 Sass 配置